### PR TITLE
explicit discard wrt clipping planes

### DIFF
--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -366,7 +366,7 @@ void main() {
     int iter = 0;
     
     // Keep track of whether texture has been sampled
-    float texture_sampled = 0;
+    int texture_sampled = 0;
     
     while (iter < nsteps) {
         for (iter=iter; iter<nsteps; iter++)
@@ -378,7 +378,7 @@ void main() {
                 // Get sample color
                 vec4 color = $sample(u_volumetex, loc);
                 float val = color.r;
-                texture_sampled += 1;
+                texture_sampled = 1;
 
                 $in_loop
             }
@@ -388,7 +388,7 @@ void main() {
     }
     
     // discard fragment if texture not sampled
-    if ( texture_sampled < 1 ) {
+    if ( texture_sampled != 1 ) {
         discard;
     }
     

--- a/napari/_vispy/vendored/volume.py
+++ b/napari/_vispy/vendored/volume.py
@@ -364,16 +364,21 @@ void main() {
     // datasets. Ugly, but it works ...
     vec3 loc = start_loc;
     int iter = 0;
+    
+    // Keep track of whether texture has been sampled
+    float texture_sampled = 0;
+    
     while (iter < nsteps) {
         for (iter=iter; iter<nsteps; iter++)
         {
-// Only sample volume if loc is not clipped by clipping planes
+            // Only sample volume if loc is not clipped by clipping planes
             float is_shown = $clip_by_planes(loc, u_shape);
             if (is_shown >= 0)
             {
                 // Get sample color
                 vec4 color = $sample(u_volumetex, loc);
                 float val = color.r;
+                texture_sampled += 1;
 
                 $in_loop
             }
@@ -381,7 +386,12 @@ void main() {
             loc += step;
         }
     }
-
+    
+    // discard fragment if texture not sampled
+    if ( texture_sampled < 1 ) {
+        discard;
+    }
+    
     $after_loop
 
     /* Set depth value - from visvis TODO


### PR DESCRIPTION
Explicitly discard fragments if ray never intersects volume, will help depth issues and avoids the weird visual bug I had