### PR TITLE
Update tests to reflect layer usage and fix

### DIFF
--- a/napari/layers/utils/_tests/test_text_manager.py
+++ b/napari/layers/utils/_tests/test_text_manager.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from napari._tests.utils import assert_colors_equal
+from napari.layers.utils._slice_input import _SliceInput
 from napari.layers.utils.string_encoding import (
     ConstantStringEncoding,
     FormatStringEncoding,
@@ -713,7 +714,6 @@ def test_copy_paste_with_derived_color():
     )
 
 
-# All pass
 @pytest.mark.parametrize(
     ('ndim', 'ndisplay', 'translation'),
     (
@@ -729,13 +729,14 @@ def test_copy_paste_with_derived_color():
     ),
 )
 def test_compute_text_coords(ndim, ndisplay, translation):
+    """See https://github.com/napari/napari/issues/5111"""
     num_points = 3
     text_manager = TextManager(
         features=pd.DataFrame(index=range(num_points)),
         translation=translation,
     )
     np.random.seed(0)
-    coords = np.random.rand(num_points, ndim)
+    coords = np.random.rand(num_points, ndim)[-ndisplay:]
 
     text_coords, _, _ = text_manager.compute_text_coords(
         coords, ndisplay=ndisplay
@@ -745,22 +746,24 @@ def test_compute_text_coords(ndim, ndisplay, translation):
     np.testing.assert_equal(text_coords, expected_coords)
 
 
-# Some orders fail
 @pytest.mark.parametrize(('order'), permutations((0, 1, 2)))
 def test_compute_text_coords_with_3D_data_2D_display(order):
+    """See https://github.com/napari/napari/issues/5111"""
     num_points = 3
     translation = np.array([5.2, -3.2, 0.1])
     text_manager = TextManager(
         features=pd.DataFrame(index=range(num_points)),
         translation=translation,
     )
+    slice_input = _SliceInput(ndisplay=2, point=(0.0,) * 3, order=order)
     np.random.seed(0)
-    coords = np.random.rand(num_points, 3)
+    coords = np.random.rand(num_points, slice_input.ndisplay)
 
     text_coords, _, _ = text_manager.compute_text_coords(
-        coords, ndisplay=2, order=order
+        coords,
+        ndisplay=slice_input.ndisplay,
+        order=slice_input.displayed,
     )
 
-    displayed_dims = list(order[1:])
-    expected_coords = coords[:, displayed_dims] + translation[displayed_dims]
+    expected_coords = coords + translation[slice_input.displayed]
     np.testing.assert_equal(text_coords, expected_coords)

--- a/napari/layers/utils/_tests/test_text_manager.py
+++ b/napari/layers/utils/_tests/test_text_manager.py
@@ -736,6 +736,9 @@ def test_compute_text_coords(ndim, ndisplay, translation):
         translation=translation,
     )
     np.random.seed(0)
+    # Cannot just use `rand(num_points, ndisplay)` because when
+    # ndim < ndisplay, we need to get ndim data which is what
+    # what layers are doing (e.g. see `Points._view_data`).
     coords = np.random.rand(num_points, ndim)[-ndisplay:]
 
     text_coords, _, _ = text_manager.compute_text_coords(

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -23,7 +23,6 @@ from napari.layers.utils.string_encoding import (
 from napari.layers.utils.style_encoding import _get_style_values
 from napari.utils.events import Event, EventedModel
 from napari.utils.events.custom_types import Array
-from napari.utils.misc import reorder_after_dim_reduction
 from napari.utils.translations import trans
 
 
@@ -253,25 +252,23 @@ class TextManager(EventedModel):
         anchor_y : str
             The vispy text anchor for the y axis
         """
-        if order is None:
-            order = range(ndisplay)
         anchor_coords, anchor_x, anchor_y = get_text_anchors(
             view_data, ndisplay, self.anchor
         )
+        # The translation should either be a scalar or be as long as
+        # the dimensionality of the associated layer.
+        # We do not have direct knowledge of that dimensionality, but
+        # can infer enough information to get the translation coordinates
+        # that need to offset the anchor coordinates.
         ndim_coords = min(ndisplay, anchor_coords.shape[1])
-        # broadcast in case translation is just a scalar
-        if self.translation.size == 1:
-            translation = np.broadcast_to(self.translation, ndim_coords)
-        else:
-            translation = self.translation
-        # get order of displayed dimensions
-        displayed_ordered = list(
-            reorder_after_dim_reduction(order[-ndim_coords:])
-        )
-        text_coords = (
-            anchor_coords[:, displayed_ordered]
-            + translation[displayed_ordered]
-        )
+        translation = self.translation
+        if translation.size > 1:
+            if order is None:
+                translation = self.translation[-ndim_coords:]
+            else:
+                order_displayed = list(order[-ndim_coords:])
+                translation = self.translation[order_displayed]
+        text_coords = anchor_coords + translation
         return text_coords, anchor_x, anchor_y
 
     def view_text(self, indices_view: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
This makes some further suggestions to https://github.com/napari/napari/issues/5111

It updates the tests to reflect usage of `compute_text_coords` by layers (i.e. `Points`, `Shapes`). They pass sliced coordinates to `compute_text_coords`, not the full data coordinates. Except in cases when `ndim < ndisplay` where sliced coordinates have `ndim` dimensionality, which is a general issue when slicing with napari that we have to workaround a little here (both in tests and in the implementation).

Given these new tests (and the existing tests), I update the implementation to something that I think should work for now.