### PR TITLE
Just use iio.imread

### DIFF
--- a/napari_builtins/io/_read.py
+++ b/napari_builtins/io/_read.py
@@ -2,19 +2,15 @@ import csv
 import itertools
 import os
 import re
-import tempfile
-import urllib.parse
 from collections.abc import Sequence
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
-from urllib.error import HTTPError, URLError
 
 import dask.array as da
 import imageio.v3 as iio
 import numpy as np
-import tifffile
 from dask import delayed
 
 from napari.utils.misc import abspath_or_url
@@ -22,8 +18,6 @@ from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from napari.types import FullLayerData, LayerData, ReaderFunction
-
-TIFFILE_EXTENSIONS = {f'*.{ext}' for ext in tifffile.TIFF.FILE_EXTENSIONS}
 
 
 def _alphanumeric_key(s: str) -> list[str | int]:
@@ -42,41 +36,13 @@ def _is_url(filename):
     return isinstance(filename, str) and URL_REGEX.match(filename) is not None
 
 
-@contextmanager
-def file_or_url_context(resource_name):
-    """Yield name of file from the given resource (i.e. file or url).
-
-    Originally vendored from scikit-image/skimage/io/util.py
-    """
-    if _is_url(resource_name):
-        url_components = urllib.parse.urlparse(resource_name)
-        _, ext = os.path.splitext(url_components.path)
-        try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as f:
-                u = urllib.request.urlopen(resource_name)
-                f.write(u.read())
-            # f must be closed before yielding
-            yield f.name
-        except (URLError, HTTPError):  # pragma: no cover
-            # could not open URL
-            os.remove(f.name)
-            raise
-        except BaseException:  # pragma: no cover
-            # could not create temporary file
-            raise
-        else:
-            os.remove(f.name)
-    else:
-        yield resource_name
-
-
 def imread(filename: str) -> np.ndarray:
-    """Custom implementation of imread to avoid skimage dependency.
+    """Dispatch reading images to imageio.v3 imread.
 
     Parameters
     ----------
     filename : string
-        The path from which to read the image.
+        The path or URI from which to read the image.
 
     Returns
     -------
@@ -88,12 +54,8 @@ def imread(filename: str) -> np.ndarray:
 
     if ext.lower() in ('.npy',):
         return np.load(filename)
-    if ext.lower() not in TIFFILE_EXTENSIONS:
-        return iio.imread(filename)
 
-    # Pre-download urls before loading them with tifffile
-    with file_or_url_context(filename) as filename:
-        return tifffile.imread(str(filename))
+    return iio.imread(str(filename))
 
 
 def _guess_zarr_path(path: str) -> bool:


### PR DESCRIPTION

If we're using the extension filtering from the yaml, then we can just use imageio to dispatch the reading to tifffile via the plugin. 
https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile_v3.html#module-imageio.plugins.tifffile_v3
The upside is iio.imread already handles URI/URL so we don't need the extra context manager either (it's just used in this file, I checked)!
https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imread.html
(so `napari https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1-Small-Region.svs` still works)

I tested this locally with svs, tiff and ndpi -- with imagecodecs installed.