### PR TITLE
Add bounding box and check state in menu bar

### DIFF
--- a/src/napari/_app_model/actions/_layerlist_context_actions.py
+++ b/src/napari/_app_model/actions/_layerlist_context_actions.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING
 
-from app_model.types import Action, SubmenuItem
+from app_model.types import Action, SubmenuItem, ToggleRule
 
 from napari._app_model.constants import MenuGroup, MenuId
 from napari._app_model.context import LayerListSelectionContextKeys as LLSCK
@@ -247,6 +247,7 @@ LAYERLIST_CONTEXT_ACTIONS: list[Action] = [
             (LLSCK.num_selected_layers > 0)
             & LLSCK.all_selected_layers_support_colorbar
         ),
+        toggled=ToggleRule(get_current=_layer_actions._are_colorbars_visible),
     ),
 ]
 

--- a/src/napari/_app_model/actions/_layerlist_context_actions.py
+++ b/src/napari/_app_model/actions/_layerlist_context_actions.py
@@ -235,8 +235,11 @@ LAYERLIST_CONTEXT_ACTIONS: list[Action] = [
         id='napari.layer.bounding_box',
         title=trans._('Bounding Box'),
         callback=_layer_actions._toggle_bounding_box,
-        menus=[MenuId.LAYERS_CONTEXT_VISUALIZATION],
+        menus=[MenuId.LAYERS_CONTEXT_VISUALIZATION, MenuId.LAYERS_VISUALIZE],
         enablement=LLSCK.num_selected_layers > 0,
+        toggled=ToggleRule(
+            get_current=_layer_actions._are_bounding_boxes_visible
+        ),
     ),
     Action(
         id='napari.layer.colorbar',

--- a/src/napari/_qt/_qapp_model/_tests/test_qapp_model_menus.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_qapp_model_menus.py
@@ -6,6 +6,7 @@ from napari._app_model import get_app_model
 from napari._app_model.constants import MenuId
 from napari._app_model.context import LayerListContextKeys as LLCK
 from napari._qt._qapp_model import build_qmodel_menu
+from napari._qt._qapp_model._tests.utils import get_submenu_action
 from napari.layers import Image
 
 
@@ -65,3 +66,22 @@ def test_update_menu_state_context(make_napari_viewer):
     viewer.window._update_file_menu_state()
     assert dummy_action.isVisible()
     assert dummy_action.isEnabled()
+
+
+def test_layers_menu_colorbar_checked(make_napari_viewer):
+    """Ensure colorbar menu item check state reflects layer colorbar visibility."""
+    viewer = make_napari_viewer()
+    layer = Image(np.random.random((10, 10)))
+    viewer.layers.append(layer)
+    viewer.layers.selection.active = layer
+    viewer.window.layers_menu.aboutToShow.emit()
+    colorbar_action, _submenu_action = get_submenu_action(
+        viewer.window.layers_menu, 'Measure', 'Colorbar'
+    )
+    submenu = _submenu_action.menu()
+    submenu.aboutToShow.emit()
+    assert not colorbar_action.isChecked()
+
+    layer.colorbar.visible = True
+    submenu.aboutToShow.emit()
+    assert colorbar_action.isChecked()

--- a/src/napari/_qt/_qapp_model/_tests/test_qapp_model_menus.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_qapp_model_menus.py
@@ -68,20 +68,29 @@ def test_update_menu_state_context(make_napari_viewer):
     assert dummy_action.isEnabled()
 
 
-def test_layers_menu_colorbar_checked(make_napari_viewer):
-    """Ensure colorbar menu item check state reflects layer colorbar visibility."""
+@pytest.mark.parametrize(
+    ('submenu_label', 'action_label', 'layer_attr'),
+    [
+        ('Measure', 'Colorbar', 'colorbar'),
+        ('Visualize', 'Bounding Box', 'bounding_box'),
+    ],
+)
+def test_layers_menu_colorbar_checked(
+    make_napari_viewer, submenu_label, action_label, layer_attr
+):
+    """Ensure menu item check state reflects layer overlay visibility."""
     viewer = make_napari_viewer()
     layer = Image(np.random.random((10, 10)))
     viewer.layers.append(layer)
     viewer.layers.selection.active = layer
     viewer.window.layers_menu.aboutToShow.emit()
-    colorbar_action, _submenu_action = get_submenu_action(
-        viewer.window.layers_menu, 'Measure', 'Colorbar'
+    action, submenu_action = get_submenu_action(
+        viewer.window.layers_menu, submenu_label, action_label
     )
-    submenu = _submenu_action.menu()
+    submenu = submenu_action.menu()
     submenu.aboutToShow.emit()
-    assert not colorbar_action.isChecked()
+    assert not action.isChecked()
 
-    layer.colorbar.visible = True
+    getattr(layer, layer_attr).visible = True
     submenu.aboutToShow.emit()
-    assert colorbar_action.isChecked()
+    assert action.isChecked()

--- a/src/napari/layers/_layer_actions.py
+++ b/src/napari/layers/_layer_actions.py
@@ -275,3 +275,13 @@ def _are_colorbars_visible(ll: LayerList) -> bool:
             for layer in ll.selection
         )
     )
+
+
+def _are_bounding_boxes_visible(ll: LayerList) -> bool:
+    return bool(
+        ll.selection
+        and all(
+            hasattr(layer, 'bounding_box') and layer.bounding_box.visible
+            for layer in ll.selection
+        )
+    )

--- a/src/napari/layers/_layer_actions.py
+++ b/src/napari/layers/_layer_actions.py
@@ -265,3 +265,13 @@ def _toggle_colorbar(ll: LayerList) -> None:
                 )
             )
         layer.colorbar.visible = not layer.colorbar.visible
+
+
+def _are_colorbars_visible(ll: LayerList) -> bool:
+    return bool(
+        ll.selection
+        and all(
+            hasattr(layer, 'colorbar') and layer.colorbar.visible
+            for layer in ll.selection
+        )
+    )


### PR DESCRIPTION
# References and relevant issues
Closes napari 7429

# Description
- Add bounding box to LAYERS_VISUALIZE (as per the issue)
- Add a ToggleRule to show the check state in the menu (works in both the layer contextual and the Layers menu)
- add a test for the check state.